### PR TITLE
Add alternative version of Amiplus - 3 tariffs

### DIFF
--- a/wmbusmeters-ha-addon/mqtt_discovery/amiplus.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/amiplus.json
@@ -23,6 +23,78 @@
         "enabled_by_default":true
      }
   },
+  "total_energy_consumption_tariff_1_kwh":{
+     "component":"sensor",
+     "discovery_payload":{
+        "device":{
+           "identifiers":[
+              "wmbusmeters_{id}"
+           ],
+           "manufacturer":"APATOR",
+           "model":"Electricity meter Apator EMU family (driver: {driver})",
+           "name":"{name}",
+           "hw_version":"{id}"
+        },
+        "name":"total energy consumption for tariff 1",
+        "unique_id":"wmbusmeters_{id}_{attribute}",
+        "state_topic":"wmbusmeters/{name}",
+        "value_template":"{{ value_json.{attribute} }}",
+        "json_attributes_topic":"wmbusmeters/{name}",
+        "icon":"mdi:transmission-tower-import",
+        "unit_of_measurement":"kWh",
+        "state_class":"total_increasing",
+        "device_class":"energy",
+        "enabled_by_default":true
+     }
+  },
+  "total_energy_consumption_tariff_2_kwh":{
+     "component":"sensor",
+     "discovery_payload":{
+        "device":{
+           "identifiers":[
+              "wmbusmeters_{id}"
+           ],
+           "manufacturer":"APATOR",
+           "model":"Electricity meter Apator EMU family (driver: {driver})",
+           "name":"{name}",
+           "hw_version":"{id}"
+        },
+        "name":"total energy consumption for tariff 2",
+        "unique_id":"wmbusmeters_{id}_{attribute}",
+        "state_topic":"wmbusmeters/{name}",
+        "value_template":"{{ value_json.{attribute} }}",
+        "json_attributes_topic":"wmbusmeters/{name}",
+        "icon":"mdi:transmission-tower-import",
+        "unit_of_measurement":"kWh",
+        "state_class":"total_increasing",
+        "device_class":"energy",
+        "enabled_by_default":true
+     }
+  },
+  "total_energy_consumption_tariff_3_kwh":{
+     "component":"sensor",
+     "discovery_payload":{
+        "device":{
+           "identifiers":[
+              "wmbusmeters_{id}"
+           ],
+           "manufacturer":"APATOR",
+           "model":"Electricity meter Apator EMU family (driver: {driver})",
+           "name":"{name}",
+           "hw_version":"{id}"
+        },
+        "name":"total energy consumption for tariff 3",
+        "unique_id":"wmbusmeters_{id}_{attribute}",
+        "state_topic":"wmbusmeters/{name}",
+        "value_template":"{{ value_json.{attribute} }}",
+        "json_attributes_topic":"wmbusmeters/{name}",
+        "icon":"mdi:transmission-tower-import",
+        "unit_of_measurement":"kWh",
+        "state_class":"total_increasing",
+        "device_class":"energy",
+        "enabled_by_default":true
+     }
+  },
   "total_energy_production_kwh":{
      "component":"sensor",
      "discovery_payload":{
@@ -36,6 +108,78 @@
            "hw_version":"{id}"
         },
         "name":"total energy production",
+        "unique_id":"wmbusmeters_{id}_{attribute}",
+        "state_topic":"wmbusmeters/{name}",
+        "value_template":"{{ value_json.{attribute} }}",
+        "json_attributes_topic":"wmbusmeters/{name}",
+        "icon":"mdi:transmission-tower-export",
+        "unit_of_measurement":"kWh",
+        "state_class":"total_increasing",
+        "device_class":"energy",
+        "enabled_by_default":true
+     }
+  },
+  "total_energy_production_tariff_1_kwh":{
+     "component":"sensor",
+     "discovery_payload":{
+        "device":{
+           "identifiers":[
+              "wmbusmeters_{id}"
+           ],
+           "manufacturer":"APATOR",
+           "model":"Electricity meter Apator EMU family (driver: {driver})",
+           "name":"{name}",
+           "hw_version":"{id}"
+        },
+        "name":"total energy production for tariff 1",
+        "unique_id":"wmbusmeters_{id}_{attribute}",
+        "state_topic":"wmbusmeters/{name}",
+        "value_template":"{{ value_json.{attribute} }}",
+        "json_attributes_topic":"wmbusmeters/{name}",
+        "icon":"mdi:transmission-tower-export",
+        "unit_of_measurement":"kWh",
+        "state_class":"total_increasing",
+        "device_class":"energy",
+        "enabled_by_default":true
+     }
+  },
+  "total_energy_production_tariff_2_kwh":{
+     "component":"sensor",
+     "discovery_payload":{
+        "device":{
+           "identifiers":[
+              "wmbusmeters_{id}"
+           ],
+           "manufacturer":"APATOR",
+           "model":"Electricity meter Apator EMU family (driver: {driver})",
+           "name":"{name}",
+           "hw_version":"{id}"
+        },
+        "name":"total energy production for tariff 2",
+        "unique_id":"wmbusmeters_{id}_{attribute}",
+        "state_topic":"wmbusmeters/{name}",
+        "value_template":"{{ value_json.{attribute} }}",
+        "json_attributes_topic":"wmbusmeters/{name}",
+        "icon":"mdi:transmission-tower-export",
+        "unit_of_measurement":"kWh",
+        "state_class":"total_increasing",
+        "device_class":"energy",
+        "enabled_by_default":true
+     }
+  },
+  "total_energy_production_tariff_3_kwh":{
+     "component":"sensor",
+     "discovery_payload":{
+        "device":{
+           "identifiers":[
+              "wmbusmeters_{id}"
+           ],
+           "manufacturer":"APATOR",
+           "model":"Electricity meter Apator EMU family (driver: {driver})",
+           "name":"{name}",
+           "hw_version":"{id}"
+        },
+        "name":"total energy production for tariff 3",
         "unique_id":"wmbusmeters_{id}_{attribute}",
         "state_topic":"wmbusmeters/{name}",
         "value_template":"{{ value_json.{attribute} }}",


### PR DESCRIPTION
Added additional 6 attributes, present on Tauron Amiplus 3 tariff meter variant. Instead of two total for consumption and production it has 6 tariff specific totals.